### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/op-bindings/bindings/registry.go
+++ b/op-bindings/bindings/registry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// layouts respresents the set of storage layouts. It is populated in an init function.
+// layouts represents the set of storage layouts. It is populated in an init function.
 var layouts = make(map[string]*solc.StorageLayout)
 
 // deployedBytecodes represents the set of deployed bytecodes. It is populated

--- a/packages/sdk/test-next/README.md
+++ b/packages/sdk/test-next/README.md
@@ -1,5 +1,5 @@
 # test-next
 
 - The new tests for the next version of sdk will use vitest
-- The vitest tests are kept here seperated from mocha tests for now
+- The vitest tests are kept here separated from mocha tests for now
 - Can find values needed in a `.env` file in `example.env`

--- a/packages/sdk/test-next/proveMessage.spec.ts
+++ b/packages/sdk/test-next/proveMessage.spec.ts
@@ -9,7 +9,7 @@ import { l1Provider, l2Provider } from './testUtils/ethersProviders'
  * This test repros the bug where legacy withdrawals are not provable
  */
 /*******
-Cast results from runnning cast tx and cast receipt on the l2 tx hash
+Cast results from running cast tx and cast receipt on the l2 tx hash
 
 cast tx 0xd66fda632b51a8b25a9d260d70da8be57b9930c4616370861526335c3e8eef81 --rpc-url https://goerli.optimism.io
 


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- Corrects "respresents" to "represents" in registry.go comment
- Fixes "seperated" to "separated" in test-next README.md
- Corrects "runnning" to "running" in proveMessage.spec.ts comment

These changes are purely cosmetic and do not affect any functionality.